### PR TITLE
Moving About component to Landing page. Removing link to About from nav.

### DIFF
--- a/front-end/src/App.js
+++ b/front-end/src/App.js
@@ -18,8 +18,6 @@ class App extends Component {
           <Link to="/main" className='icon'> Main </Link>
           {"  "}
           <Link to="/waiting" className='links'> Waiting </Link>
-          {"  "}
-          <Link to="/about-us" className='icon'> About </Link>
         </nav>
     <div className="mainbody">
     <Switch>
@@ -27,7 +25,6 @@ class App extends Component {
       <Route path="/main" component={Home} />
       <Route path="/chat" component={ChatPage} />
       <Route path="/waiting" component={Wait} />
-      <Route path="/about-us" component={About} />
     </Switch>
     </div>
 

--- a/front-end/src/components/About/About.js
+++ b/front-end/src/components/About/About.js
@@ -18,10 +18,10 @@ const About = () => {
             <h1>Proudly Coded By</h1>
             {team.map( (el,i) =>
             <p>{el.name}
-                <a href={el.github}><GoMarkGithub /></a>
-                <a href={el.linkedin}><IoSocialIcon /></a>
+                <a href={el.github} target="_blank" ><GoMarkGithub /></a>
+                <a href={el.linkedin} target="_blank" ><IoSocialIcon /></a>
             </p>)}
-            <p>C4Q Access Code 4.2 Full Stack Web Development Fellows</p>
+            <p id="c4q">C4Q Access Code 4.2 Full Stack Web Development Fellows</p>
         </div>
     )
 }

--- a/front-end/src/components/About/about.css
+++ b/front-end/src/components/About/about.css
@@ -1,3 +1,6 @@
+#about {
+    margin-top: 75px;
+}
 #about a {
     margin-left: 10px;
     color: #1b9aaa;
@@ -5,5 +8,9 @@
 }
 
 #about p {
-    margin-top: 3em;
+    margin: auto;
+}
+
+#c4q {
+    padding-top: 1em;
 }

--- a/front-end/src/components/Landing/Landing.js
+++ b/front-end/src/components/Landing/Landing.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Link} from 'react-router-dom';
 import './landingpg.css';
+import About from '../About/About';
 
 const Landing = () => {
     return (
@@ -9,7 +10,8 @@ const Landing = () => {
             <p>Chat about your favorite TV shows!</p>
             <p>Connect with other fans!</p>
             <p>Be free to be a chatterbox!</p>
-            {/* <Link to="/tv-guide" id="enter"><p>Enter</p></Link> */}
+            <Link to="/main" id="enter"><p>Enter</p></Link>
+            <About />
         </div>
     )
 }


### PR DESCRIPTION
I imported the About Us component to the Landing page. I removed the link to About from the navigation. For the GitHub and LinkedIn icons on About, I tweaked the links. They now open a new window when they are clicked. This way, the user still has a tab open for the ChatterBox app.